### PR TITLE
Feature: Allow common rules if rule names are unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ desprite searches your CSS for qualified<sup>1</sup> rules, and crops out the re
 
     $ node desprite.js -i test-src\sprites.png -c test-src\sprites.css
     ```
+
+##Runtime Options##
+
+* `-v`, `--verbose`: Verbose debug output
+* `-u`, `--unique`: Allow common rules (aka: images) if the rule names are unique
+
   
 ##Dependencies##
 

--- a/desprite.js
+++ b/desprite.js
@@ -25,6 +25,8 @@ var counter = {
 	ok: 0
 };
 
+var uniqueNames = argv.unique || false;
+
 main();
 
 function main() {
@@ -85,7 +87,9 @@ function validate(rules) {
 		});
 
 		if (isRuleValid(decs)) {
-			var key = [decs.width, decs.height, decs.pos.x, decs.pos.y].join('_');
+			var key = (uniqueNames)
+						 ? [name, decs.width, decs.height, decs.pos.x, decs.pos.y].join('_')
+						 : [decs.width, decs.height, decs.pos.x, decs.pos.y].join('_');
 			if (valids[key]) {
 				if (log.invalid) logDuplicate(name, valids[key].name);
 			} else {

--- a/lib/args.js
+++ b/lib/args.js
@@ -13,6 +13,8 @@ module.exports = function () {
 	.describe('v', 'Verbose progress messages')
 	.alias('p', 'parsed')
 	.describe('p', 'Verbose progress messages shown for valid rules only')
+	.alias('u', 'unique')
+	.describe('u', 'Include duplicate rules if their rule identifiers are unique')
 	.alias('s', 'spawn')
 	.describe('s', 'Max threads spawned for split operation (default: 50)')
 	.argv;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desprite",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Split a sprite image by CSS usage",
   "homepage": "https://github.com/fmovlex/desprite",
   "bin": {

--- a/test-src/sprites.css
+++ b/test-src/sprites.css
@@ -24,3 +24,8 @@
     width: 32px;
     height: 32px;
 }
+.unique27077 {
+    background-position: -8px -8px;
+    width: 32px;
+    height: 32px;
+}


### PR DESCRIPTION
Really simple feature, but the recent(1) "ignore duplicate rule" change kinda broke my use of this little tool.. :)

This PR has a quick CLI argument change to get around it; you want..?

(1): Well, I think it was recent anyway... Not too sure. I've been making use of this script for a few months now. O.o Thanks, by the way, its been super useful in the strangest of ways..
### System used:
- OS: Win 8.1 Pro
- Node: `0.10.38`
- GraphicsMagick: `1.3.21 2015-02-28 Q8`
### Test Output

```
E:\Dev Stuff\<path-trimmed>\desprite>node desprite.js -i test-src\sprites.png -c test-src\sprites.css -v
argv : { _: [],
  '$0': 'node E:\\Dev Stuff\\<path-trimmed>\\desprite\\desprite.js',
  i: 'test-src\\sprites.png',
  image: 'test-src\\sprites.png',
  c: 'test-src\\sprites.css',
  css: 'test-src\\sprites.css',
  v: true,
  verbose: true }
found 6 css entries, parsing...
rule world91 invalid for split, skipping...
rule world91 OK, saved for split... (32, 32, 8, 8)
rule phone43 OK, saved for split... (32, 32, 60, 23)
rule network11 OK, saved for split... (32, 32, 9, 59)
rule alarm54 OK, saved for split... (32, 32, 60, 77)
rule unique27077 is a duplicate of rule world91, skipping...
parsed 4 valid rules out of a total 6, starting split...
processed chunk 1
all done! 4 successfully split images and 0 errors.

E:\Dev Stuff\<path-trimmed>\desprite>node desprite.js -i test-src\sprites.png -c test-src\sprites.css -v --unique
argv : { _: [],
  '$0': 'node E:\\Dev Stuff\\<path-trimmed>\\desprite\\desprite.js',
  i: 'test-src\\sprites.png',
  image: 'test-src\\sprites.png',
  c: 'test-src\\sprites.css',
  css: 'test-src\\sprites.css',
  v: true,
  verbose: true,
  unique: true,
  u: true }
found 6 css entries, parsing...
rule world91 invalid for split, skipping...
rule world91 OK, saved for split... (32, 32, 8, 8)
rule phone43 OK, saved for split... (32, 32, 60, 23)
rule network11 OK, saved for split... (32, 32, 9, 59)
rule alarm54 OK, saved for split... (32, 32, 60, 77)
rule unique27077 OK, saved for split... (32, 32, 8, 8)
parsed 5 valid rules out of a total 6, starting split...
processed chunk 1
all done! 5 successfully split images and 0 errors.

E:\Dev Stuff\<path-trimmed>\desprite>node desprite.js -i test-src\sprites.png -c test-src\sprites.css -v -u
argv : { _: [],
  '$0': 'node E:\\Dev Stuff\\<path-trimmed>\\desprite\\desprite.js',
  i: 'test-src\\sprites.png',
  image: 'test-src\\sprites.png',
  c: 'test-src\\sprites.css',
  css: 'test-src\\sprites.css',
  v: true,
  verbose: true,
  u: true,
  unique: true }
found 6 css entries, parsing...
rule world91 invalid for split, skipping...
rule world91 OK, saved for split... (32, 32, 8, 8)
rule phone43 OK, saved for split... (32, 32, 60, 23)
rule network11 OK, saved for split... (32, 32, 9, 59)
rule alarm54 OK, saved for split... (32, 32, 60, 77)
rule unique27077 OK, saved for split... (32, 32, 8, 8)
parsed 5 valid rules out of a total 6, starting split...
processed chunk 1
all done! 5 successfully split<path-trimmed>Pr<path-trimmed>>

E:\Dev Stuff\<path-trimmed>\desprite>node desprite.js
Split a sprite image by the css usage.
Usage: node E:\Dev Stuff\<path-trimmed>\desprite\desprite.js

Options:
  -i, --image    Sprite image                                                  [required]
  -c, --css      CSS file                                                      [required]
  -o, --output   Output folder path (default: split/)
  -v, --verbose  Verbose progress messages
  -p, --parsed   Verbose progress messages shown for valid rules only
  -u, --unique   Include duplicate rules if their rule identifiers are unique
  -s, --spawn    Max threads spawned for split operation (default: 50)

Missing required arguments: i, c
```
